### PR TITLE
Resizing LED bar according to overscan settings - Added opt 1541 emul function option

### DIFF
--- a/Config/Frodo.opt
+++ b/Config/Frodo.opt
@@ -1,0 +1,8 @@
+### [frodo_resolution]:[384x288]:[384x288|400x300|640x480|832x576|960x720|1024x768|1024x1024]
+frodo_resolution = "384x288"
+### [frodo_frameskip]:[0]:[auto|0|1|2|3|4|5]
+frodo_frameskip = "1"
+### [frodo_1541emul]:[true]:[true|false]
+frodo_1541emul = "false"
+### [frodo_overscan]:[none]:[none|auto|small|medium|large]
+frodo_overscan = "none"

--- a/Src/Display.cpp
+++ b/Src/Display.cpp
@@ -519,7 +519,7 @@ void C64Display::Update(void)
 //      r.y = DISPLAY_Y + 10 - overscan_led_bar_y; //14
 //      retro_FillRect(screen, &r, shadow_gray);
       
-      // Drive LEDs horizontal borders
+      // LED bar Drive Leds borders
 //      r.w = 16; //16
 //      for (i = 2; i < 6; i++)
 //      {
@@ -530,7 +530,7 @@ void C64Display::Update(void)
 //         retro_FillRect(screen, &r, shine_gray);
 //      }
       
-      // LED bar vertical separation Lines
+      //Vertical separation Lines
       r.y = DISPLAY_Y - overscan_led_bar_y;
       r.w = 1;
       r.h = overscan_led_bar_h; //15
@@ -542,7 +542,7 @@ void C64Display::Update(void)
          retro_FillRect(screen, &r, shadow_gray);
       }
       
-      // Drive LEDs vertical borders
+      // Led vertical left & right borders
 //      r.y = DISPLAY_Y + 4 - overscan_led_bar_y; 
 //      r.h = 4;
 //      for (i = 2; i < 6; i++)
@@ -553,14 +553,14 @@ void C64Display::Update(void)
 //         retro_FillRect(screen, &r, shine_gray);
 //      }
       
-      // Drive LEDs
+      // Drive Leds
       r.y = DISPLAY_Y + 3 - overscan_led_bar_y;
       r.w = 14;
       r.h = 4; //5
       for (i = 0; i < 4; i++)
       {
          int c;
-         r.x = DISPLAY_X * (i+2) / 6 - 6; //- 23;
+         r.x = DISPLAY_X * (i+2) / 6 - 3; //- 23;
          switch (led_state[i])
          {
             case LED_ON:
@@ -576,22 +576,22 @@ void C64Display::Update(void)
          retro_FillRect(screen, &r, c);
       }
       
-      // LED bar texts
+      // LED bar Texts
       int yTPos = 1;
 #if defined(SF2000)
       if ( shiftstate == 1 )
-         draw_string(screen, DISPLAY_X + 35, DISPLAY_Y + yTPos - overscan_led_bar_y - 1, "SH", green, fill_gray);
+         draw_string(screen, DISPLAY_X + 35, DISPLAY_Y + yTPos - overscan_led_bar_y - 1, "F\x0E", green, fill_gray);
       else
-         draw_string(screen, DISPLAY_X + 35, DISPLAY_Y + yTPos - overscan_led_bar_y - 1, "SH", black, fill_gray);
+         draw_string(screen, DISPLAY_X + 35, DISPLAY_Y + yTPos - overscan_led_bar_y - 1, "F\x0E", black, fill_gray);
       if ( joystickport == 1 )
          draw_string(screen, DISPLAY_X + (7*8) + 5, DISPLAY_Y + yTPos - overscan_led_bar_y - 1, "J2", black, fill_gray);
       else
          draw_string(screen, DISPLAY_X + (7*8) + 5, DISPLAY_Y + yTPos - overscan_led_bar_y - 1, "J1", black, fill_gray);
 #endif
-      draw_string(screen, DISPLAY_X * 1/6 + 25, DISPLAY_Y + yTPos - overscan_led_bar_y, "D8", black, fill_gray);
-      draw_string(screen, DISPLAY_X * 2/6 + 25, DISPLAY_Y + yTPos - overscan_led_bar_y, "D9", black, fill_gray);
-      draw_string(screen, DISPLAY_X * 3/6 + 25, DISPLAY_Y + yTPos - overscan_led_bar_y, "D10", black, fill_gray);
-      draw_string(screen, DISPLAY_X * 4/6 + 25, DISPLAY_Y + yTPos - overscan_led_bar_y, "D11", black, fill_gray);
+      draw_string(screen, DISPLAY_X * 1/6 + 25, DISPLAY_Y + yTPos - overscan_led_bar_y, "D\x12" "8", black, fill_gray);
+      draw_string(screen, DISPLAY_X * 2/6 + 25, DISPLAY_Y + yTPos - overscan_led_bar_y, "D\x12" "9", black, fill_gray);
+      draw_string(screen, DISPLAY_X * 3/6 + 25, DISPLAY_Y + yTPos - overscan_led_bar_y, "D\x12" "10", black, fill_gray);
+      draw_string(screen, DISPLAY_X * 4/6 + 25, DISPLAY_Y + yTPos - overscan_led_bar_y, "D\x12" "11", black, fill_gray);
    }
 
 	// Update display

--- a/Src/Display.cpp
+++ b/Src/Display.cpp
@@ -92,6 +92,11 @@ extern int overscan_crop_right;
 extern int overscan_crop_top;
 extern int overscan_crop_bottom;
 
+extern int overscan_led_bar_x;
+extern int overscan_led_bar_y;
+extern int overscan_led_bar_w;
+extern int overscan_led_bar_h;
+
 /* forward declarations */
 int Retro_PollEvent(uint8 *key_matrix,
       uint8 *rev_matrix, uint8 *joystick);
@@ -495,46 +500,67 @@ void C64Display::Update(void)
    {
       unsigned i;
       // Draw speedometer/LEDs
-      r.x   = 0;
-      r.y	= DISPLAY_Y;
-      r.w	= DISPLAY_X;
-      r.h	= 15;
-
+      // Commented some bar UI elements to simplify resizing
+      // (LED bar lower border, LED drive horizontal borders, Led drive vertical borders)
+      
+      // LED bar Rectangle
+      r.x = 0;
+      r.y = DISPLAY_Y - overscan_led_bar_y;
+      r.w = DISPLAY_X;
+      r.h = overscan_led_bar_h; //15
       retro_FillRect(screen, &r, fill_gray);
-      r.w = DISPLAY_X; r.h = 1;
+      
+      // LED bar upper border
+      r.w = DISPLAY_X;
+      r.h = 1;
       retro_FillRect(screen, &r, shine_gray);
-      r.y = DISPLAY_Y + 14;
-      retro_FillRect(screen, &r, shadow_gray);
-      r.w = 16;
-
-      for (i = 2; i < 6; i++)
-      {
-         r.x = DISPLAY_X * i/5 - 24; r.y = DISPLAY_Y + 4;
-         retro_FillRect(screen, &r, shadow_gray);
-         r.y = DISPLAY_Y + 10;
-         retro_FillRect(screen, &r, shine_gray);
-      }
-      r.y = DISPLAY_Y; r.w = 1; r.h = 15;
+      
+      // LED bar lower border 
+//      r.y = DISPLAY_Y + 10 - overscan_led_bar_y; //14
+//      retro_FillRect(screen, &r, shadow_gray);
+      
+      // Drive LEDs horizontal borders
+//      r.w = 16; //16
+//      for (i = 2; i < 6; i++)
+//      {
+//         r.x = DISPLAY_X * i/5 + 2; //- 24;
+//         r.y = DISPLAY_Y + 4 - overscan_led_bar_y;
+//         retro_FillRect(screen, &r, shadow_gray);
+//         r.y = DISPLAY_Y + 10;
+//         retro_FillRect(screen, &r, shine_gray);
+//      }
+      
+      // LED bar vertical separation Lines
+      r.y = DISPLAY_Y - overscan_led_bar_y;
+      r.w = 1;
+      r.h = overscan_led_bar_h; //15
       for (i = 0; i < 5; i++)
       {
-         r.x = DISPLAY_X * i / 5;
-         retro_FillRect(screen, &r, shine_gray);
-         r.x = DISPLAY_X * (i+1) / 5 - 1;
+//         r.x = DISPLAY_X * i / 6 + 10;
+//         retro_FillRect(screen, &r, shine_gray);
+         r.x = DISPLAY_X * (i+1) / 6 + 19;
          retro_FillRect(screen, &r, shadow_gray);
       }
-      r.y = DISPLAY_Y + 4; r.h = 7;
-      for (i = 2; i < 6; i++)
-      {
-         r.x = DISPLAY_X * i/5 - 24;
-         retro_FillRect(screen, &r, shadow_gray);
-         r.x = DISPLAY_X * i/5 - 9;
-         retro_FillRect(screen, &r, shine_gray);
-      }
-      r.y = DISPLAY_Y + 5; r.w = 14; r.h = 5;
+      
+      // Drive LEDs vertical borders
+//      r.y = DISPLAY_Y + 4 - overscan_led_bar_y; 
+//      r.h = 4;
+//      for (i = 2; i < 6; i++)
+//      {
+//         r.x = DISPLAY_X * i/5 + 1; //- 24;
+//         retro_FillRect(screen, &r, shadow_gray);
+//         r.x = DISPLAY_X * i/5 + 16; //- 9;
+//         retro_FillRect(screen, &r, shine_gray);
+//      }
+      
+      // Drive LEDs
+      r.y = DISPLAY_Y + 3 - overscan_led_bar_y;
+      r.w = 14;
+      r.h = 4; //5
       for (i = 0; i < 4; i++)
       {
          int c;
-         r.x = DISPLAY_X * (i+2) / 5 - 23;
+         r.x = DISPLAY_X * (i+2) / 6 - 6; //- 23;
          switch (led_state[i])
          {
             case LED_ON:
@@ -549,20 +575,23 @@ void C64Display::Update(void)
          }
          retro_FillRect(screen, &r, c);
       }
+      
+      // LED bar texts
+      int yTPos = 1;
 #if defined(SF2000)
       if ( shiftstate == 1 )
-         draw_string(screen, DISPLAY_X + 8, DISPLAY_Y + 4, "R ON", green, fill_gray);
+         draw_string(screen, DISPLAY_X + 35, DISPLAY_Y + yTPos - overscan_led_bar_y - 1, "SH", green, fill_gray);
       else
-         draw_string(screen, DISPLAY_X + 8, DISPLAY_Y + 4, "R OFF", black, fill_gray);
+         draw_string(screen, DISPLAY_X + 35, DISPLAY_Y + yTPos - overscan_led_bar_y - 1, "SH", black, fill_gray);
       if ( joystickport == 1 )
-         draw_string(screen, DISPLAY_X + (7*8), DISPLAY_Y + 4, "J 2", black, fill_gray);
+         draw_string(screen, DISPLAY_X + (7*8) + 5, DISPLAY_Y + yTPos - overscan_led_bar_y - 1, "J2", black, fill_gray);
       else
-         draw_string(screen, DISPLAY_X + (7*8), DISPLAY_Y + 4, "J 1", black, fill_gray);
+         draw_string(screen, DISPLAY_X + (7*8) + 5, DISPLAY_Y + yTPos - overscan_led_bar_y - 1, "J1", black, fill_gray);
 #endif
-      draw_string(screen, DISPLAY_X * 1/5 + 8, DISPLAY_Y + 4, "D\x12 8", black, fill_gray);
-      draw_string(screen, DISPLAY_X * 2/5 + 8, DISPLAY_Y + 4, "D\x12 9", black, fill_gray);
-      draw_string(screen, DISPLAY_X * 3/5 + 8, DISPLAY_Y + 4, "D\x12 10", black, fill_gray);
-      draw_string(screen, DISPLAY_X * 4/5 + 8, DISPLAY_Y + 4, "D\x12 11", black, fill_gray);
+      draw_string(screen, DISPLAY_X * 1/6 + 25, DISPLAY_Y + yTPos - overscan_led_bar_y, "D8", black, fill_gray);
+      draw_string(screen, DISPLAY_X * 2/6 + 25, DISPLAY_Y + yTPos - overscan_led_bar_y, "D9", black, fill_gray);
+      draw_string(screen, DISPLAY_X * 3/6 + 25, DISPLAY_Y + yTPos - overscan_led_bar_y, "D10", black, fill_gray);
+      draw_string(screen, DISPLAY_X * 4/6 + 25, DISPLAY_Y + yTPos - overscan_led_bar_y, "D11", black, fill_gray);
    }
 
 	// Update display

--- a/libretro/core/core-mapper.cpp
+++ b/libretro/core/core-mapper.cpp
@@ -520,7 +520,13 @@ int Retro_PollEvent(uint8 *key_matrix, uint8 *rev_matrix, uint8 *joystick)
 	{
 		mbt[RETRO_DEVICE_ID_JOYPAD_SELECT]=0;
 	}
+	
+	// Map a ESC-RUN/STOP to "L" button
 	check_key_with_delay(RETRO_DEVICE_ID_JOYPAD_L, mbt, RETRO_DEVICE_ID_JOYPAD_L, MATRIX(7, 7));
+	// Map a SPACE to "X" button
+	check_key_with_delay(RETRO_DEVICE_ID_JOYPAD_X, mbt, RETRO_DEVICE_ID_JOYPAD_X, MATRIX(7, 4));
+	// Map ENTER to "Y" button
+	check_key_with_delay(RETRO_DEVICE_ID_JOYPAD_Y, mbt, RETRO_DEVICE_ID_JOYPAD_Y, MATRIX(0, 1));
 
 	if ( input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R) )
 	{

--- a/libretro/core/libretro.cpp
+++ b/libretro/core/libretro.cpp
@@ -33,6 +33,9 @@ int overscan_crop_right = 24;
 int overscan_crop_top = 12;
 int overscan_crop_bottom = 12;
 
+// Frodo_1541emul variable
+bool frodo_1541emul = true;
+
 // Shutdown flag
 static bool shutdown_requested = false;
 
@@ -262,6 +265,27 @@ static void update_variables(void)
       //reset_screen();
    }
 
+   // Handle Processor-level 1541 emulation
+   var.key   = "frodo_1541emul";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "true") == 0)
+      {
+         frodo_1541emul = true;  // Enable processor-level 1541 emulation
+      }
+      else
+      {
+         frodo_1541emul = false;  // Disable processor-level 1541 emulation
+      }
+      ThePrefs.Emul1541Proc = frodo_1541emul;
+      
+      if (log_cb)
+         log_cb(RETRO_LOG_INFO, "Emul1541Proc set to: %s\n", 
+                var.value);
+   }
+   
    // Handle frameskip option
    var.key   = "frodo_frameskip";
    var.value = NULL;

--- a/libretro/core/libretro.cpp
+++ b/libretro/core/libretro.cpp
@@ -33,6 +33,12 @@ int overscan_crop_right = 24;
 int overscan_crop_top = 12;
 int overscan_crop_bottom = 12;
 
+// Overscan led bar variables - Initialize with default "auto" values
+int overscan_led_bar_x = 0;
+int overscan_led_bar_y = 27;
+int overscan_led_bar_w = 0;
+int overscan_led_bar_h = 11;
+
 // Frodo_1541emul variable
 bool frodo_1541emul = true;
 
@@ -320,34 +326,59 @@ static void update_variables(void)
          overscan_crop_right = 0;
          overscan_crop_top = 0;
          overscan_crop_bottom = 0;
+         
+         overscan_led_bar_x = 0;
+         overscan_led_bar_y = 0;
+         overscan_led_bar_w = 0;
+         overscan_led_bar_h = 16;
       }
       else if (strcmp(var.value, "small") == 0)
       {
          overscan_crop_left = 8;
          overscan_crop_right = 8;
-         overscan_crop_top = 4;
-         overscan_crop_bottom = 4;
+         overscan_crop_top = 8;
+         overscan_crop_bottom = 12;
+         
+         overscan_led_bar_x = 0;
+         overscan_led_bar_y = 7;
+         overscan_led_bar_w = 0;
+         overscan_led_bar_h = 11;
       }
       else if (strcmp(var.value, "medium") == 0)
       {
          overscan_crop_left = 16;
          overscan_crop_right = 16;
-         overscan_crop_top = 8;
-         overscan_crop_bottom = 8;
+         overscan_crop_top = 16;
+         overscan_crop_bottom = 22;
+         
+         overscan_led_bar_x = 0;
+         overscan_led_bar_y = 17;
+         overscan_led_bar_w = 0;
+         overscan_led_bar_h = 11;
       }
       else if (strcmp(var.value, "large") == 0)
       {
-         overscan_crop_left = 32;
-         overscan_crop_right = 32;
-         overscan_crop_top = 16;
-         overscan_crop_bottom = 16;
+         overscan_crop_left = 30; //32
+         overscan_crop_right = 28; //32
+         overscan_crop_top = 32; //16
+         overscan_crop_bottom = 42; //16
+         
+         overscan_led_bar_x = 0;
+         overscan_led_bar_y = 36;
+         overscan_led_bar_w = 0;
+         overscan_led_bar_h = 11;
       }
       else // "auto" or any other value
       {
          overscan_crop_left = 24;
          overscan_crop_right = 24;
-         overscan_crop_top = 12;
-         overscan_crop_bottom = 12;
+         overscan_crop_top = 24;
+         overscan_crop_bottom = 32;
+         
+         overscan_led_bar_x = 0;
+         overscan_led_bar_y = 27;
+         overscan_led_bar_w = 0;
+         overscan_led_bar_h = 11;
       }
       
       if (log_cb)
@@ -602,9 +633,11 @@ void retro_run(void)
       video_cb(Retro_Screen,retrow,retroh,retrow<<PIXEL_BYTES);
       
       // Upload silent audio samples during splash display
-      if(SND==1)
-         for(int x=0;x<snd_sampler;x++)
-            audio_cb(0,0);
+      // Commented because a buzzing noise is heard during splash in GB300
+
+//      if(SND==1)
+//         for(int x=0;x<snd_sampler;x++)
+//            audio_cb(0,0);
       
       // Don't switch to emulator thread during splash - wait for core boot
       return;

--- a/libretro/core/libretro_core_options.h
+++ b/libretro/core/libretro_core_options.h
@@ -73,6 +73,17 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "auto"
    },
+   {
+      "frodo_1541emul",
+      "Enable processor-level 1541 emulation",
+      "Enable processor-level 1541 emulation. If set to true, operation are slower but better compability.",
+      {
+         { "true",   "On" },
+         { "false",   "Off" },
+         { NULL, NULL },
+      },
+      "true"
+   },
    { NULL, NULL, NULL, {{0}}, NULL },
 };
 


### PR DESCRIPTION
- Added a new option for 1541 emulation with true/false settings (better compatibility vs loading speed).
- Changed overscan mode X/Y cropping pixels to get right proportions.
- Added position variables for LED bar elements resizing.